### PR TITLE
Add test for obs column conservation

### DIFF
--- a/tests/test_apply_changes.py
+++ b/tests/test_apply_changes.py
@@ -37,3 +37,8 @@ def test_apply_changes(uzzan_h5ad, uzzan_csv):
     assert len(updated_adata.var.index) == len(adata.var.index) + len(
         df_changes[df_changes["action"] == "copy"]
     ), "Unexpected number of rows in updated AnnData object."
+
+    # Ensure all observation columns are preserved
+    assert set(adata.obs.columns) == set(
+        updated_adata.obs.columns
+    ), "Observation columns changed after applying changes"

--- a/tests/test_cli_apply.py
+++ b/tests/test_cli_apply.py
@@ -1,4 +1,5 @@
 import subprocess
+import anndata as ad
 
 
 def test_cli_apply_changes(uzzan_h5ad, uzzan_csv, tmp_path):
@@ -28,3 +29,12 @@ def test_cli_apply_changes(uzzan_h5ad, uzzan_csv, tmp_path):
 
     # Check that the output file was created
     assert output_file.exists(), "Output file was not created."
+
+    # Load input and output AnnData objects to verify observation columns
+    original_adata = ad.read_h5ad(input_file)
+    updated_adata = ad.read_h5ad(output_file)
+
+    # Ensure all observation columns are preserved
+    assert set(original_adata.obs.columns) == set(
+        updated_adata.obs.columns
+    ), "Observation columns changed after applying changes"


### PR DESCRIPTION
This is a step of finding the reason behind [this issue](https://github.com/nf-core/scdownstream/issues/160)